### PR TITLE
Fix: Update manual sections (fixes #56)

### DIFF
--- a/adapt-authoring.json
+++ b/adapt-authoring.json
@@ -3,7 +3,7 @@
   "documentation": {
     "enable": true,
     "manualPages": {
-      "writing-an-api.md": "basics"
+      "writing-an-api.md": "development"
     }
   }
 }


### PR DESCRIPTION
https://github.com/adapt-security/adapt-authoring-api/issues/56

### Fix
* Changed the manual section for writing-an-api.md from "basics" to "development" in adapt-authoring.json