### PR TITLE
Fix: Return null from findOne with strict: false (fixes #75)

### DIFF
--- a/lib/AbstractApiModule.js
+++ b/lib/AbstractApiModule.js
@@ -636,7 +636,7 @@ class AbstractApiModule extends AbstractModule {
     if (options.strict !== false && !results.length) {
       throw this.app.errors.NOT_FOUND.setData({ id: query, type: options.schemaName })
     }
-    return results[0]
+    return results[0] ?? null
   }
 
   /**


### PR DESCRIPTION
### Fix
* Return `null` instead of `undefined` from `findOne` when `strict: false` and no results are found, matching the standard convention for database findOne APIs

### Testing
1. Run integration tests
2. Verify `findOne({ ... }, { strict: false })` returns `null` when no document matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)