### PR TITLE
Fix: Convert handler factories to direct methods (fixes #84)

### DIFF
--- a/lib/AbstractApiModule.js
+++ b/lib/AbstractApiModule.js
@@ -142,8 +142,6 @@ class AbstractApiModule extends AbstractModule {
     const config = await loadRouteConfig(this.rootDir, this, {
       schema: 'apiroutes',
       handlerAliases: {
-        default: this.requestHandler(),
-        query: this.queryHandler(),
         serveSchema: this.serveSchema.bind(this)
       },
       defaults: new URL('../default-routes.json', import.meta.url).pathname
@@ -380,135 +378,129 @@ class AbstractApiModule extends AbstractModule {
    * Middleware to handle a generic API request. Supports POST, GET, PUT and DELETE of items in the database.
    * @return {Function} Express middleware function
    */
-  requestHandler () {
-    const requestHandler = async (req, res, next) => {
-      const method = req.method.toLowerCase()
-      const func = this[httpMethodToDBFunction(method)]
-      if (!func) {
-        return next(this.app.errors.HTTP_METHOD_NOT_SUPPORTED.setData({ method }))
-      }
-      let data
-      try {
-        await this.requestHook.invoke(req)
-        const preCheck = method !== 'get' && method !== 'post'
-        const postCheck = method === 'get'
-        if (preCheck) {
-          await this.checkAccess(req, req.apiData.query)
-        }
-        data = await func.apply(this, argsFromReq(req))
-        if (postCheck) {
-          data = await this.checkAccess(req, data)
-        }
-        data = await this.sanitise(req.apiData.schemaName, data, { isInternal: true, strict: false })
-      } catch (e) {
-        return next(e)
-      }
-      if (Array.isArray(data) && req.params._id) { // special case for when _id param is present
-        if (!data.length) {
-          return next(this.app.errors.NOT_FOUND.setData({ id: req.params._id, type: req.apiData.schemaName }))
-        }
-        data = data[0]
-      }
-      if (method !== 'get') {
-        const resource = Array.isArray(data) ? req.apiData.query : data._id.toString()
-        this.log('debug', `API_${func.name.toUpperCase()}`, resource, 'by', req.auth.user._id.toString())
-      }
-      res.status(this.mapStatusCode(method)).json(data)
+  async requestHandler (req, res, next) {
+    const method = req.method.toLowerCase()
+    const func = this[httpMethodToDBFunction(method)]
+    if (!func) {
+      return next(this.app.errors.HTTP_METHOD_NOT_SUPPORTED.setData({ method }))
     }
-    return requestHandler
+    let data
+    try {
+      await this.requestHook.invoke(req)
+      const preCheck = method !== 'get' && method !== 'post'
+      const postCheck = method === 'get'
+      if (preCheck) {
+        await this.checkAccess(req, req.apiData.query)
+      }
+      data = await func.apply(this, argsFromReq(req))
+      if (postCheck) {
+        data = await this.checkAccess(req, data)
+      }
+      data = await this.sanitise(req.apiData.schemaName, data, { isInternal: true, strict: false })
+    } catch (e) {
+      return next(e)
+    }
+    if (Array.isArray(data) && req.params._id) { // special case for when _id param is present
+      if (!data.length) {
+        return next(this.app.errors.NOT_FOUND.setData({ id: req.params._id, type: req.apiData.schemaName }))
+      }
+      data = data[0]
+    }
+    if (method !== 'get') {
+      const resource = Array.isArray(data) ? req.apiData.query : data._id.toString()
+      this.log('debug', `API_${func.name.toUpperCase()}`, resource, 'by', req.auth.user._id.toString())
+    }
+    res.status(this.mapStatusCode(method)).json(data)
   }
 
   /**
    * Express request handler for advanced API queries. Supports collation/limit/page/skip/sort and pagination. For incoming query data to be correctly parsed, it must be sent as body data using a POST request.
    * @return {function}
    */
-  queryHandler () {
-    const queryHandler = async (req, res, next) => {
-      try {
-        const opts = {
-          schemaName: req.apiData.schemaName,
-          collectionName: req.apiData.collectionName
-        }
-        const mongoOpts = {}
-        // find and remove mongo options from the query
-        Object.entries(req.apiData.query).forEach(([key, val]) => {
-          if (['collation', 'limit', 'page', 'skip', 'sort'].includes(key)) {
-            try {
-              mongoOpts[key] = JSON.parse(req.apiData.query[key])
-            } catch (e) {
-              this.log('warn', `failed to parse query ${key} param '${mongoOpts[key]}', ${e}`)
-            }
-            delete req.apiData.query[key]
-          } else {
-            // otherwise assume we have a query field or option and store for later processing
-            opts[key] = val
-          }
-        })
-        // handle search parameter
-        const search = req.apiData.query.search
-        if (search) {
-          delete req.apiData.query.search
+  async queryHandler (req, res, next) {
+    try {
+      const opts = {
+        schemaName: req.apiData.schemaName,
+        collectionName: req.apiData.collectionName
+      }
+      const mongoOpts = {}
+      // find and remove mongo options from the query
+      Object.entries(req.apiData.query).forEach(([key, val]) => {
+        if (['collation', 'limit', 'page', 'skip', 'sort'].includes(key)) {
           try {
-            const schema = await this.getSchema(req.apiData.schemaName)
-            if (schema && schema.built && schema.built.properties) {
-              const searchableFields = Object.keys(schema.built.properties).filter(
-                field => schema.built.properties[field].isSearchable === true
-              )
-              if (searchableFields.length) {
-                // escape special regex characters to prevent ReDoS attacks
-                const escapedSearch = search.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-                const regex = { $regex: escapedSearch, $options: 'i' }
-                const searchConditions = searchableFields.map(f => ({ [f]: regex }))
-                // merge with existing $or if present
-                if (req.apiData.query.$or) {
-                  req.apiData.query.$and = [
-                    { $or: req.apiData.query.$or },
-                    { $or: searchConditions }
-                  ]
-                  delete req.apiData.query.$or
-                } else {
-                  req.apiData.query.$or = searchConditions
-                }
+            mongoOpts[key] = JSON.parse(req.apiData.query[key])
+          } catch (e) {
+            this.log('warn', `failed to parse query ${key} param '${mongoOpts[key]}', ${e}`)
+          }
+          delete req.apiData.query[key]
+        } else {
+          // otherwise assume we have a query field or option and store for later processing
+          opts[key] = val
+        }
+      })
+      // handle search parameter
+      const search = req.apiData.query.search
+      if (search) {
+        delete req.apiData.query.search
+        try {
+          const schema = await this.getSchema(req.apiData.schemaName)
+          if (schema && schema.built && schema.built.properties) {
+            const searchableFields = Object.keys(schema.built.properties).filter(
+              field => schema.built.properties[field].isSearchable === true
+            )
+            if (searchableFields.length) {
+              // escape special regex characters to prevent ReDoS attacks
+              const escapedSearch = search.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+              const regex = { $regex: escapedSearch, $options: 'i' }
+              const searchConditions = searchableFields.map(f => ({ [f]: regex }))
+              // merge with existing $or if present
+              if (req.apiData.query.$or) {
+                req.apiData.query.$and = [
+                  { $or: req.apiData.query.$or },
+                  { $or: searchConditions }
+                ]
+                delete req.apiData.query.$or
+              } else {
+                req.apiData.query.$or = searchConditions
               }
             }
-          } catch (e) {
-            this.log('warn', `failed to process search parameter, ${e.message}`)
           }
+        } catch (e) {
+          this.log('warn', `failed to process search parameter, ${e.message}`)
         }
-        req.apiData.query = await this.parseQuery(req.apiData.schemaName, req.body, mongoOpts)
-        // remove any valid query keys from the options
-        Object.keys(req.apiData.query).forEach(key => delete opts[key])
-
-        await this.requestHook.invoke(req)
-
-        await this.setUpPagination(req, res, mongoOpts)
-
-        let results = await this.find(req.apiData.query, opts, mongoOpts)
-
-        results = await this.checkAccess(req, results)
-
-        // If checkAccess filtered some results, fetch more to fill the page
-        const pageSize = mongoOpts.limit
-        if (pageSize && results.length < pageSize) {
-          let fetchSkip = mongoOpts.skip + pageSize
-          while (results.length < pageSize) {
-            const extra = await this.find(req.apiData.query, opts, { ...mongoOpts, skip: fetchSkip })
-            if (!extra.length) break
-            const filtered = await this.checkAccess(req, extra)
-            results = results.concat(filtered)
-            fetchSkip += extra.length
-          }
-          if (results.length > pageSize) results = results.slice(0, pageSize)
-        }
-
-        results = await this.sanitise(req.apiData.schemaName, results, { isInternal: true, strict: false })
-
-        res.status(this.mapStatusCode('get')).json(results)
-      } catch (e) {
-        return next(e)
       }
+      req.apiData.query = await this.parseQuery(req.apiData.schemaName, req.body, mongoOpts)
+      // remove any valid query keys from the options
+      Object.keys(req.apiData.query).forEach(key => delete opts[key])
+
+      await this.requestHook.invoke(req)
+
+      await this.setUpPagination(req, res, mongoOpts)
+
+      let results = await this.find(req.apiData.query, opts, mongoOpts)
+
+      results = await this.checkAccess(req, results)
+
+      // If checkAccess filtered some results, fetch more to fill the page
+      const pageSize = mongoOpts.limit
+      if (pageSize && results.length < pageSize) {
+        let fetchSkip = mongoOpts.skip + pageSize
+        while (results.length < pageSize) {
+          const extra = await this.find(req.apiData.query, opts, { ...mongoOpts, skip: fetchSkip })
+          if (!extra.length) break
+          const filtered = await this.checkAccess(req, extra)
+          results = results.concat(filtered)
+          fetchSkip += extra.length
+        }
+        if (results.length > pageSize) results = results.slice(0, pageSize)
+      }
+
+      results = await this.sanitise(req.apiData.schemaName, results, { isInternal: true, strict: false })
+
+      res.status(this.mapStatusCode('get')).json(results)
+    } catch (e) {
+      return next(e)
     }
-    return queryHandler
   }
 
   /**


### PR DESCRIPTION
### Fix
* Convert `requestHandler` and `queryHandler` from factory methods (returning closures) to direct async handler methods, fixing a mismatch where `loadRouteConfig` would bind the factory itself as the Express handler — causing all default-template routes to hang indefinitely

### Update
* Remove `default` and `query` handler aliases from `setValues()` since `loadRouteConfig` now correctly resolves `requestHandler` and `queryHandler` via `target[handlerStr].bind(target)`

### Testing
1. Run module tests: `npm test` (all pass — note `AbstractApiModule.spec.js` requires peer deps from the monorepo)
2. Start the app, login, verify:
   - `GET /api/tags` returns 200
   - `POST /api/tags/query` returns 200
   - `GET /api/users` returns 200
   - `POST /api/content/query` returns 200
3. Verify roles module (uses legacy route config) still works