### PR TITLE
Update: Remove unnecessary Promise.all from synchronous schema.sanitise calls

### DIFF
--- a/lib/AbstractApiModule.js
+++ b/lib/AbstractApiModule.js
@@ -327,11 +327,9 @@ class AbstractApiModule extends AbstractModule {
    * @return {Promise} Resolves with the sanitised data
    */
   async sanitise (schemaName, data, options) {
+    const schema = await this.getSchema(schemaName, data)
     const isArray = Array.isArray(data)
-    const sanitised = await Promise.all((isArray ? data : [data]).map(async d => {
-      const schema = await this.getSchema(schemaName, d)
-      return schema.sanitise(d, options)
-    }))
+    const sanitised = (isArray ? data : [data]).map(d => schema.sanitise(d, options))
     return isArray ? sanitised : sanitised[0]
   }
 


### PR DESCRIPTION
### Fixes adapt-security/adapt-authoring-jsonschema#58

### Update
* Remove `Promise.all` + `async` map from `sanitise()` — `schema.sanitise()` is now synchronous in adapt-schemas v3
* Fetch schema once instead of per-item since `getSchema` returns the same schema for the same name

### Testing
1. Run `npm test`
2. Verify API sanitisation still works for insert/update/find operations

Depends on https://github.com/adapt-security/adapt-authoring-jsonschema/pull/57

🤖 Generated with [Claude Code](https://claude.com/claude-code)