### PR TITLE
Fix: build sanitise schema per item to restore subclass dispatch

### DIFF
--- a/lib/AbstractApiModule.js
+++ b/lib/AbstractApiModule.js
@@ -327,9 +327,12 @@ class AbstractApiModule extends AbstractModule {
    * @return {Promise} Resolves with the sanitised data
    */
   async sanitise (schemaName, data, options) {
-    const schema = await this.getSchema(schemaName, data)
     const isArray = Array.isArray(data)
-    const sanitised = (isArray ? data : [data]).map(d => schema.sanitise(d, options))
+    const items = isArray ? data : [data]
+    const sanitised = await Promise.all(items.map(async d => {
+      const schema = await this.getSchema(schemaName, d)
+      return schema.sanitise(d, options)
+    }))
     return isArray ? sanitised : sanitised[0]
   }
 


### PR DESCRIPTION
### Fix
* Restore the per-item `getSchema` call inside `sanitise()` so subclasses that override `getSchema` to dispatch on the data argument (notably `ContentModule`) get the right schema for each item.

### Background
[PR #97](https://github.com/adapt-security/adapt-authoring-api/pull/97) hoisted the `getSchema` call out of the per-item loop on the basis that `getSchema` is idempotent for a given `schemaName`. That holds for `AbstractApiModule.getSchema` but not for subclasses that override it to vary by data — `ContentModule.getSchema` returns a different schema per content type / `_component` / enabled-plugin set.

With the hoisted call, `ContentModule.getSchema` received the array as its `data` argument, fell back to the base `content` schema, and dropped all component-specific and extension fields when sanitising GET responses. Concretely, GETting a graphic component returned only base fields — `_graphic`, `_vanilla`, `_pageLevelProgress` etc. were stripped, so the editor lost the asset thumbnail on revisit.

PR #97's stated rationale ("`schema.sanitise()` is now synchronous") is correct but didn't actually motivate removing the loop — the `await` in the previous code was for `getSchema` (still async), not `sanitise`.

### Cost
Bounded by:
* `AbstractApiModule.find/findOne` — already DataCached (`AbstractApiModule.js:650`).
* `ContentModule._schemaCache` — already keys built schemas by `schemaName + enabledPlugins`.

Worst case for a 100-item batch with 10 unique component types: ~11 DB hits and ~10 schema builds on a cold cache; subsequent items hit the cache. Same shape as pre-PR-97 behaviour.

### Testing
1. `npm test`
2. With `adapt-authoring-content`, `GET /api/content/<componentId>` for a graphic component and confirm `_graphic`, `_vanilla`, `_pageLevelProgress`, etc. appear in the response.