### PR TITLE
Fix: build sanitise schema per item to restore subclass dispatch (fixes #100)

### DIFF
--- a/lib/AbstractApiModule.js
+++ b/lib/AbstractApiModule.js
@@ -327,9 +327,12 @@ class AbstractApiModule extends AbstractModule {
    * @return {Promise} Resolves with the sanitised data
    */
   async sanitise (schemaName, data, options) {
-    const schema = await this.getSchema(schemaName, data)
     const isArray = Array.isArray(data)
-    const sanitised = (isArray ? data : [data]).map(d => schema.sanitise(d, options))
+    const items = isArray ? data : [data]
+    const sanitised = await Promise.all(items.map(async d => {
+      const schema = await this.getSchema(schemaName, d)
+      return schema.sanitise(d, options)
+    }))
     return isArray ? sanitised : sanitised[0]
   }
 


### PR DESCRIPTION
### Fixes #100

### Fix
* Restore per-item `getSchema` dispatch in `sanitise()` so subclasses overriding `getSchema` on data (notably `ContentModule`) get the right schema per item; previously the array was passed as `data`, falling back to the base content schema and stripping component-specific / extension fields from GET responses.