### PR TITLE
Update: Expose matching-document count via X-Adapt-Total header

### DIFF
--- a/lib/AbstractApiModule.js
+++ b/lib/AbstractApiModule.js
@@ -542,7 +542,7 @@ class AbstractApiModule extends AbstractModule {
   }
 
   /**
-   * Validates and sets the relevant pagination options (limit, skip) and HTTP headers (X-Adapt-Page, X-Adapt-PageTotal, Link).
+   * Validates and sets the relevant pagination options (limit, skip) and HTTP headers (X-Adapt-Page, X-Adapt-PageTotal, X-Adapt-Total, Link).
    * @param {external:ExpressRequest} req
    * @param {external:ExpressResponse} res
    * @param {Object} mongoOpts The MongoDB options
@@ -568,6 +568,7 @@ class AbstractApiModule extends AbstractModule {
     res.set('X-Adapt-Page', page)
     res.set('X-Adapt-PageSize', pageSize)
     res.set('X-Adapt-PageTotal', pageTotal)
+    res.set('X-Adapt-Total', docCount)
 
     if (pageTotal > 1) {
       // absolute URL with paging params removed


### PR DESCRIPTION
### Update
- Add an `X-Adapt-Total` response header to paginated query responses, carrying the total count of documents matching the query (`docCount`).

The count is already computed in `setUpPagination` to derive `X-Adapt-PageTotal`, so this exposes an existing value at no extra cost — it sits alongside the existing `X-Adapt-Page` / `X-Adapt-PageSize` / `X-Adapt-PageTotal` headers.

This lets clients render an accurate "N–M of T" range (and exact arrow disabled-states) instead of inferring an approximate count from `pageTotal × pageSize`, which over-counts the final page.

### Testing
- Verified `setUpPagination` still sets the existing headers and the new `X-Adapt-Total` reflects the matching-document count.