### PR TITLE
New: Add queryHook for role-agnostic query filtering

### DIFF
--- a/lib/AbstractApiModule.js
+++ b/lib/AbstractApiModule.js
@@ -110,12 +110,22 @@ class AbstractApiModule extends AbstractModule {
     this.accessCheckHook = new Hook()
     /**
      * Hook invoked before a query runs, allowing observers to merge access-control clauses into
-     * `req.apiData.query`. Preferred over `accessCheckHook` for filtering: keeps pagination counts
-     * and the `Link` header accurate, and avoids any need to top up short pages.
+     * `req.apiData.query`. Preferred over `accessCheckHook` for access filtering: keeps pagination
+     * counts and the `Link` header accurate, and avoids any need to top up short pages.
      * Skipped for super users so they see unfiltered results, matching `checkAccess` behaviour.
+     * For user-driven query filters that must apply regardless of role, use `queryHook` instead.
      * @type {Hook}
      */
     this.accessQueryHook = new Hook()
+    /**
+     * Hook invoked before a list query runs, allowing observers to merge user-driven filter clauses
+     * into `req.apiData.query` (e.g. dashboard filters sourced from another collection). Unlike
+     * `accessQueryHook` this runs for every user, including super users — it expresses what the user
+     * asked to see, not what they are permitted to see. Runs after `requestHook` and before
+     * pagination, so counts and the `Link` header stay accurate.
+     * @type {Hook}
+     */
+    this.queryHook = new Hook({ mutable: true })
 
     await this.setValues()
     this.validateValues()
@@ -495,6 +505,7 @@ class AbstractApiModule extends AbstractModule {
       Object.keys(req.apiData.query).forEach(key => delete opts[key])
 
       await this.requestHook.invoke(req)
+      await this.queryHook.invoke(req)
       if (!req.auth.isSuper) await this.accessQueryHook.invoke(req)
 
       await this.setUpPagination(req, res, mongoOpts)


### PR DESCRIPTION
### New
* Add `queryHook`, a mutable hook invoked in `queryHandler` for **every** user (after `requestHook`, before pagination), letting observers merge user-driven filter clauses into `req.apiData.query`.

This complements `accessQueryHook` (#103), which is deliberately skipped for super users so they see unfiltered results. That bypass is correct for *access* filtering ("what may this user see") but silently breaks *user-driven* list filters ("what did this user ask to see") — e.g. projects-dashboard filters sourced from another collection — which must apply regardless of role. Such filters previously had no role-agnostic seam to attach to; `queryHook` is that seam. Running before pagination keeps counts and the `Link` header accurate.

### Testing
1. Tap `queryHook` from a module and merge a clause into `req.apiData.query`.
2. As a **super admin**, hit a list/`query` endpoint and confirm the clause is applied (whereas an `accessQueryHook` clause is not).
3. As a non-super user, confirm both hooks still apply and pagination counts remain correct.